### PR TITLE
    CredentialsType moved to CollectorInitiated specific settings

### DIFF
--- a/DSCResources/MSFT_xWEFSubscription/MSFT_xWEFSubscription.psm1
+++ b/DSCResources/MSFT_xWEFSubscription/MSFT_xWEFSubscription.psm1
@@ -168,12 +168,12 @@ function Set-TargetResource
     <Locale Language="$Locale"/>
     <LogFile>$LogFile</LogFile>
     <PublisherName>Microsoft-Windows-EventCollector</PublisherName>
-    <CredentialsType>$CredentialsType</CredentialsType>
 
 "@
 
     if ($SubscriptionType -eq 'CollectorInitiated') {
     $Create += @"
+    <CredentialsType>$CredentialsType</CredentialsType>
     <EventSources>
 
 "@


### PR DESCRIPTION
SourceInitiated SubscriptionTypes not working. Moved  CredentialsType under CollectorInitiated specific settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwindowseventforwarding/13)
<!-- Reviewable:end -->
